### PR TITLE
perf: minor optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Installation
 ============
 
 You need to
-ensure you are using at least OpenResty 1.9.3.1 or a custom nginx build including ngx_lua 0.9.16. Also, You need to configure
+ensure you are using at least OpenResty 1.11.2.1 or a custom nginx build including ngx_lua 0.10.6. Also, You need to configure
 the [lua_package_path](https://github.com/openresty/lua-nginx-module#lua_package_path) directive to
 add the path of your lua-resty-limit-traffic source tree to ngx_lua's Lua module search path, as in
 

--- a/lib/resty/limit/conn.lua
+++ b/lib/resty/limit/conn.lua
@@ -56,16 +56,10 @@ function _M.incoming(self, key, commit)
             end
 
             if commit then
-                -- FIXME we really need dict:incr_or_init() to avoid race
-                -- conditions here.
                 local err
-                conn, err = dict:incr(key, 1)
+                conn, err = dict:incr(key, 1, 0)
                 if not conn then
-                    if err ~= "not found" then
-                        return nil, err
-                    end
-
-                    dict:add(key, 1)
+                    return nil, err
                 end
 
                 self.committed = true
@@ -92,24 +86,10 @@ function _M.incoming(self, key, commit)
 
     else
         if commit then
-            -- FIXME we should use dict:incr_or_init() to simplify the twisted
-            -- code snippet below
-            local ok, err = dict:add(key, 1)
-            if not ok then
-                if err == "found" then
-                    -- FIXME we are having a small race condition here. we
-                    -- may exceed the "max" threshold if the threshold is
-                    -- small enough.
-                    conn, err = dict:incr(key, 1)
-                    if not conn then
-                        return nil, err
-                    end
-
-                else
-                    return nil, err
-                end
-            else
-                conn = 1
+            local err
+            conn, err = dict:incr(key, 1, 0)
+            if not conn then
+                return nil, err
             end
 
             self.committed = true

--- a/lib/resty/limit/conn.lua
+++ b/lib/resty/limit/conn.lua
@@ -61,11 +61,11 @@ function _M.incoming(self, key, commit)
                 local err
                 conn, err = dict:incr(key, 1)
                 if not conn then
-                    if err == "not found" then
-                        dict:add(key, 1)
-                    else
+                    if err ~= "not found" then
                         return nil, err
                     end
+
+                    dict:add(key, 1)
                 end
 
                 self.committed = true

--- a/lib/resty/limit/req.lua
+++ b/lib/resty/limit/req.lua
@@ -17,6 +17,7 @@ local abs = math.abs
 local tonumber = tonumber
 local type = type
 local assert = assert
+local max = math.max
 
 
 -- TODO: we could avoid the tricky FFI cdata when lua_shared_dict supports
@@ -91,12 +92,7 @@ function _M.incoming(self, key, commit)
         -- we do not handle changing rate values specifically. the excess value
         -- can get automatically adjusted by the following formula with new rate
         -- values rather quickly anyway.
-        excess = tonumber(rec.excess) - rate * abs(elapsed) / 1000 + 1000
-
-        if excess < 0 then
-            -- ngx.log(ngx.WARN, "excess: ", excess / 1000)
-            excess = 0
-        end
+        excess = max(tonumber(rec.excess) - rate * abs(elapsed) / 1000 + 1000, 0)
 
         -- print("excess: ", excess)
 
@@ -134,10 +130,7 @@ function _M.uncommit(self, key)
 
     local rec = ffi_cast(const_rec_ptr_type, v)
 
-    local excess = tonumber(rec.excess) - 1000
-    if excess < 0 then
-        excess = 0
-    end
+    local excess = max(tonumber(rec.excess) - 1000, 0)
 
     rec_cdata.excess = excess
     rec_cdata.last = rec.last

--- a/lib/resty/limit/traffic.lua
+++ b/lib/resty/limit/traffic.lua
@@ -4,6 +4,9 @@
 -- (like instances of the resty.limit.req and resty.limit.conn classes).
 
 
+local max = math.max
+
+
 local _M = {
     _VERSION = '0.01'
 }
@@ -43,9 +46,8 @@ function _M.combine(limiters, keys, states)
         if states then
             states[i] = err
         end
-        if delay > max_delay then
-            max_delay = delay
-        end
+
+        max_delay = max(max_delay, delay)
     end
     return max_delay
 end


### PR DESCRIPTION
As per http://wiki.luajit.org/Numerical-Computing-Performance-Guide, this gets rid of some branches in favor of `math.max()`.