### PR TITLE
refactor: incr or init

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Installation
 ============
 
 You need to
-ensure you are using at least OpenResty 1.9.3.1 or a custom nginx build including ngx_lua 0.9.16. Also, You need to configure
+ensure you are using at least OpenResty 1.11.2.1 or a custom nginx build including ngx_lua 0.10.6. Also, You need to configure
 the [lua_package_path](https://github.com/openresty/lua-nginx-module#lua_package_path) directive to
 add the path of your lua-resty-limit-traffic source tree to ngx_lua's Lua module search path, as in
 

--- a/lib/resty/limit/conn.lua
+++ b/lib/resty/limit/conn.lua
@@ -56,16 +56,10 @@ function _M.incoming(self, key, commit)
             end
 
             if commit then
-                -- FIXME we really need dict:incr_or_init() to avoid race
-                -- conditions here.
                 local err
-                conn, err = dict:incr(key, 1)
+                conn, err = dict:incr(key, 1, 0)
                 if not conn then
-                    if err ~= "not found" then
-                        return nil, err
-                    end
-
-                    dict:add(key, 1)
+                    return nil, err
                 end
 
                 self.committed = true
@@ -92,24 +86,10 @@ function _M.incoming(self, key, commit)
 
     else
         if commit then
-            -- FIXME we should use dict:incr_or_init() to simplify the twisted
-            -- code snippet below
-            local ok, err = dict:add(key, 1)
-            if not ok then
-                if err == "found" then
-                    -- FIXME we are having a small race condition here. we
-                    -- may exceed the "max" threshold if the threshold is
-                    -- small enough.
-                    conn, err = dict:incr(key, 1)
-                    if not conn then
-                        return nil, err
-                    end
-
-                else
-                    return nil, err
-                end
-            else
-                conn = 1
+            local err
+            conn, err = dict:incr(key, 1, 0)
+            if not conn then
+                return nil, err
             end
 
             self.committed = true

--- a/lib/resty/limit/conn.lua
+++ b/lib/resty/limit/conn.lua
@@ -61,11 +61,11 @@ function _M.incoming(self, key, commit)
                 local err
                 conn, err = dict:incr(key, 1)
                 if not conn then
-                    if err == "not found" then
-                        dict:add(key, 1)
-                    else
+                    if err ~= "not found" then
                         return nil, err
                     end
+
+                    dict:add(key, 1)
                 end
 
                 self.committed = true


### PR DESCRIPTION
Use the `init?` argument of `incr()` available in ngx_lua `0.10.6+` and taking care of the FIXMEs that were in the code.