### PR TITLE
bugfix: traffic: unsure we uncommit previous limiters if a limiter rejects while committing a state

### DIFF
--- a/lib/resty/limit/traffic.lua
+++ b/lib/resty/limit/traffic.lua
@@ -40,7 +40,7 @@ function _M.combine(limiters, keys, states)
         if not delay then
             for j = 1, i - 1 do
                 -- we intentionally ignore any errors returned below.
-                lim:uncommit(keys[j])
+                limiters[j]:uncommit(keys[j])
             end
             return nil, err
         end

--- a/t/traffic.t
+++ b/t/traffic.t
@@ -206,3 +206,77 @@ $/s
 --- no_error_log
 [error]
 [lua]
+
+
+
+=== TEST 3: sanity (uncommit() previous limiters if a limiter rejects while committing a state)
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local limit_traffic = require "resty.limit.traffic"
+
+            local limit_mock = {}
+            limit_mock.__index = limit_mock
+
+            function limit_mock.new(_, _, reject_on_commit)
+                return setmetatable({
+                    counters = {},
+                    reject_on_commit = reject_on_commit,
+                }, limit_mock)
+            end
+
+            function limit_mock:incoming(key, commit)
+                local count = self.counters[key] or 0
+
+                count = count + 1
+
+                if commit then
+                    self.counters[key] = count
+
+                    if self.reject_on_commit then
+                        return nil, "rejected by mock limiter"
+                    end
+                end
+
+                return count
+            end
+
+            function limit_mock:uncommit(key)
+                local count = self.counters[key] or 0
+                if count > 0 then
+                    count = count - 1
+                end
+
+                self.counters[key] = count
+            end
+
+            local lim1 = limit_mock.new(nil, 2)
+            local lim2 = limit_mock.new(nil, 2)
+            local lim3 = limit_mock.new(nil, 2, true)
+            local lim4 = limit_mock.new(nil, 2)
+
+            local limiters = {lim1, lim2, lim3, lim4}
+
+            local keys = {"foo", "bar", "baz", "bat"}
+
+            local delay, err = limit_traffic.combine(limiters, keys)
+            if not delay then
+                ngx.say(err)
+            end
+
+            ngx.say("state lim1: ", lim1:incoming(keys[1])) -- should be 1 because previous combine() call was uncommitted
+            ngx.say("state lim2: ", lim2:incoming(keys[2])) -- should be 1 because previous combine() call was uncommitted
+            ngx.say("state lim3: ", lim3:incoming(keys[3]))
+        }
+    }
+--- request
+    GET /t
+--- response_body
+rejected by mock limiter
+state lim1: 1
+state lim2: 1
+state lim3: 2
+--- no_error_log
+[error]
+[lua]


### PR DESCRIPTION
The testing approach uses a mock limiter module to easily reproduce the issue.