### PR TITLE
feature: new module resty.limit.rate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ install:
   - git clone https://github.com/openresty/no-pool-nginx.git ../no-pool-nginx
   - git clone https://github.com/openresty/lua-resty-lrucache.git ../lua-resty-lrucache
   - git clone https://github.com/openresty/lua-resty-core.git ../lua-resty-core
+  - git clone https://github.com/openresty/lua-resty-lock.git ../lua-resty-lock
   - git clone -b v2.1-agentzh https://github.com/openresty/luajit2.git
 
 script:

--- a/README.md
+++ b/README.md
@@ -265,7 +265,9 @@ the traffic, either request rate or request concurrency (or both).
 
 * [resty.limit.req](lib/resty/limit/req.md) provides request rate limiting and adjustment based on the "leaky bucket" method.
 * [resty.limit.conn](lib/resty/limit/conn.md) provides request concurrency level limiting and adjustment based on extra delays.
-* [resty.limit.traffic](lib/resty/limit/traffic.md) provides an aggregator to combine multiple instances of either the [resty.limit.req](lib/resty/limit/req.md) or [resty.limit.conn](lib/resty/limit/conn.md) classes (or both).
+* [resty.limit.count](lib/resty/limit/count.md) provides request counts limiting by a fixed number of requests in given time window.
+* [resty.limit.rate](lib/resty/limit/rate.md) provides request rate limiting and adjustment based on the "token bucket" method.
+* [resty.limit.traffic](lib/resty/limit/traffic.md) provides an aggregator to combine multiple instances of either the [resty.limit.req](lib/resty/limit/req.md) or [resty.limit.conn](lib/resty/limit/conn.md) classes or any user class which has a compatible API (or multiple).
 
 Please check out these Lua modules' own documentation for more details.
 
@@ -363,6 +365,8 @@ See Also
 ========
 * module [resty.limit.req](lib/resty/limit/req.md)
 * module [resty.limit.conn](lib/resty/limit/conn.md)
+* module [resty.limit.count](lib/resty/limit/count.md)
+* module [resty.limit.rate](lib/resty/limit/rate.md)
 * module [resty.limit.traffic](lib/resty/limit/traffic.md)
 * the ngx_lua module: https://github.com/openresty/lua-nginx-module
 * OpenResty: https://openresty.org/

--- a/lib/resty/limit/conn.md
+++ b/lib/resty/limit/conn.md
@@ -191,7 +191,7 @@ key so that we can avoid a single client from flooding our service with too many
 
     Please note that this module
 does not prefix nor suffix the user key so it is the user's responsibility to ensure the key
-is unique in the `lua_shared_dict` shm zone).
+is unique in the `lua_shared_dict` shm zone.
 * `commit` is a boolean value. If set to `true`, the object will actually record the event
 in the shm zone backing the current object; otherwise it would just be a "dry run" (which is the default).
 
@@ -403,6 +403,7 @@ See Also
 ========
 * module [resty.limit.req](./req.md)
 * module [resty.limit.count](./count.md)
+* module [resty.limit.rate](./rate.md)
 * module [resty.limit.traffic](./traffic.md)
 * library [lua-resty-limit-traffic](../../../README.md)
 * the ngx_lua module: https://github.com/openresty/lua-nginx-module

--- a/lib/resty/limit/count.md
+++ b/lib/resty/limit/count.md
@@ -14,7 +14,9 @@ Table of Contents
     * [incoming](#incoming)
     * [uncommit](#uncommit)
 * [Limiting Granularity](#limiting-granularity)
-* [Installation](#installation)
+* [Community](#community)
+    * [English Mailing List](#english-mailing-list)
+    * [Chinese Mailing List](#chinese-mailing-list)
 * [Bugs and Patches](#bugs-and-patches)
 * [Authors](#authors)
 * [Copyright and License](#copyright-and-license)
@@ -124,7 +126,7 @@ This method accepts the following arguments:
 as the key so that we limit rate per host name. Otherwise, we can also use the authorization header value as the
 key so that we can set a rate for individual user.
 
-    Please note that this module does not prefix nor suffix the user key so it is the user's responsibility to ensure the key is unique in the `lua_shared_dict` shm zone).
+    Please note that this module does not prefix nor suffix the user key so it is the user's responsibility to ensure the key is unique in the `lua_shared_dict` shm zone.
 * `commit` is a boolean value. If set to `true`, the object will actually record the event
 in the shm zone backing the current object; otherwise it would just be a "dry run" (which is the default).
 
@@ -166,12 +168,32 @@ Please see [library installation instructions](../../../README.md#installation).
 
 [Back to TOC](#table-of-contents)
 
+Community
+=========
+
+[Back to TOC](#table-of-contents)
+
+English Mailing List
+--------------------
+
+The [openresty-en](https://groups.google.com/group/openresty-en) mailing list is for English speakers.
+
+[Back to TOC](#table-of-contents)
+
+Chinese Mailing List
+--------------------
+
+The [openresty](https://groups.google.com/group/openresty) mailing list is for Chinese speakers.
+
+[Back to TOC](#table-of-contents)
+
 Bugs and Patches
 ================
 
 Please report bugs or submit patches by
 
 1. creating a ticket on the [GitHub Issue Tracker](https://github.com/openresty/lua-resty-limit-traffic/issues),
+1. or posting to the [OpenResty community](#community).
 
 [Back to TOC](#table-of-contents)
 
@@ -204,7 +226,9 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 See Also
 ========
+* module [resty.limit.req](./req.md)
 * module [resty.limit.conn](./conn.md)
+* module [resty.limit.rate](./rate.md)
 * module [resty.limit.traffic](./traffic.md)
 * library [lua-resty-limit-traffic](../../../README.md)
 * the ngx_lua module: https://github.com/openresty/lua-nginx-module

--- a/lib/resty/limit/rate.lua
+++ b/lib/resty/limit/rate.lua
@@ -1,0 +1,294 @@
+-- limit request rate using the token bucket method:
+--    https://en.wikipedia.org/wiki/Token_bucket
+
+
+local ffi = require "ffi"
+local math = require "math"
+local lock = require "resty.lock"
+
+
+local ffi_cast = ffi.cast
+local ffi_str = ffi.string
+
+local type = type
+local assert = assert
+local ngx_now = ngx.now
+local floor = math.floor
+local ngx_shared = ngx.shared
+local setmetatable = setmetatable
+
+
+ffi.cdef[[
+    struct lua_resty_limit_rate_rec {
+        int64_t        avail;
+        uint64_t       last;  /* time in milliseconds */
+    };
+]]
+local const_rec_ptr_type = ffi.typeof("const struct lua_resty_limit_rate_rec*")
+local rec_size = ffi.sizeof("struct lua_resty_limit_rate_rec")
+
+local rec_cdata = ffi.new("struct lua_resty_limit_rate_rec")
+
+
+local _M = {
+    _VERSION = "0.01",
+}
+
+
+local mt = {
+    __index = _M
+}
+
+
+local function acquire_lock(self, key)
+    if not self.lock_enable then
+        return true
+    end
+
+    local lock, err = lock:new(self.locks_shdict_name)
+    if not lock then
+        return nil, err
+    end
+
+    self.lock = lock
+
+    return lock:lock(key)
+end
+
+
+local function release_lock(self)
+    if not self.lock_enable then
+        return true
+    end
+
+    local lock = self.lock
+
+    return lock:unlock()
+end
+
+
+local function update(self, key, avail, last)
+    local dict = self.dict
+
+    rec_cdata.avail = avail
+    rec_cdata.last = last
+    dict:set(key, ffi_str(rec_cdata, rec_size))
+
+    -- ngx.log(ngx.ERR, "key = ", key, " avail = ", avail, " last = ", last)
+end
+
+
+local function adjust(self, key, now)
+    local dict = self.dict
+
+    local res = {
+        last = now,
+        avail = self.capacity
+    }
+
+    local v = dict:get(key)
+    if v then
+        if type(v) ~= "string" or #v ~= rec_size then
+            return nil, "shdict abused by other users"
+        end
+
+        local rec = ffi_cast(const_rec_ptr_type, v)
+
+        res.last = tonumber(rec.last)
+        res.avail = tonumber(rec.avail)
+    end
+
+    local tick = floor((now - res.last) / self.interval)
+    res.last = res.last + tick * self.interval
+
+    if res.avail >= self.capacity then
+        return res
+    end
+
+    res.avail = res.avail + tick * self.quantum
+    if res.avail > self.capacity then
+        res.avail = self.capacity
+    end
+
+    return res
+end
+
+
+function _M.new(dict_name, interval, capacity, quantum, max_wait, opts)
+    local dict = ngx_shared[dict_name]
+    if not dict then
+        return nil, "shared dict not found"
+    end
+
+    if not quantum then
+        quantum = 1
+    end
+
+    assert(interval > 0 and capacity >= 0 and quantum > 0)
+
+    if not opts then
+        opts = {}
+    end
+
+    local lock_enable = opts.lock_enable or false
+    local locks_shdict_name = opts.locks_shdict_name or "locks"
+
+    local self = {
+        dict = dict,
+        interval = interval,
+        capacity = capacity,
+        quantum = quantum,
+        max_wait = max_wait,
+
+        lock_enable = lock_enable,
+        locks_shdict_name = locks_shdict_name,
+    }
+
+    return setmetatable(self, mt)
+end
+
+
+function _M.set_max_wait(self, max_wait)
+    self.max_wait = max_wait
+end
+
+
+function _M.take(self, key, count, commit, fake_now)
+    assert(key and count > 0)
+
+    local now = ngx_now() * 1000
+
+    -- just for testing
+    if type(fake_now) == "number" then
+        now = fake_now
+    end
+
+    local res, err = acquire_lock(self, key)
+    if not res then
+        return nil, err
+    end
+
+    local res, err = adjust(self, key, now)
+    if not res then
+        release_lock(self)
+        return nil, err
+    end
+
+    local last = res.last
+    local avail = res.avail
+
+    avail = avail - count
+    if avail >= 0 then
+        if commit then
+            update(self, key, avail, last)
+        end
+        release_lock(self)
+        return 0, avail
+    end
+
+    local quantum = self.quantum
+    local tick = floor((-avail + quantum - 1) / quantum)
+    local wait_time = tick * self.interval - (now - last)
+
+    local max_wait = self.max_wait
+    if type(max_wait) == "number" and wait_time > max_wait then
+        if commit then
+            update(self, key, avail + count, last)
+        end
+        release_lock(self)
+        return nil, "rejected"
+    end
+
+    if commit then
+        update(self, key, avail, last)
+    end
+    release_lock(self)
+
+    return wait_time / 1000, avail
+end
+
+
+function _M.take_available(self, key, count, fake_now)
+    if type(key) ~= "string" or count <= 0 then
+        return 0
+    end
+
+    local now = ngx_now() * 1000
+
+    -- just for testing
+    if type(fake_now) == "number" then
+        now = fake_now
+    end
+
+    local res, err = acquire_lock(self, key)
+    if not res then
+        return nil, err
+    end
+
+    local res, err = adjust(self, key, now)
+    if not res then
+        release_lock(self)
+        return nil, err
+    end
+
+    local last = res.last
+    local avail = res.avail
+
+    if avail <= 0 then
+        update(self, key, avail, last)
+        release_lock(self)
+        return 0
+    end
+
+    if count > avail then
+        count = avail
+    end
+
+    avail = avail - count
+    update(self, key, avail, last)
+    release_lock(self)
+
+    return count
+end
+
+
+function _M.incoming(self, key, commit)
+    return self:take(key, 1, commit)
+end
+
+
+function _M.uncommit(self, key)
+    assert(key)
+
+    local res, err = acquire_lock(self, key)
+    if not res then
+        return nil, err
+    end
+
+    local dict = self.dict
+
+    local v = dict:get(key)
+    if not v then
+        release_lock(self)
+        return nil, "not found"
+    end
+
+    if type(v) ~= "string" or #v ~= rec_size then
+        release_lock(self)
+        return nil, "shdict abused by other users"
+    end
+
+    local rec = ffi_cast(const_rec_ptr_type, v)
+    local avail = tonumber(rec.avail) + 1
+    if avail > self.capacity then
+        avail = self.capacity
+    end
+
+    update(self, key, avail, rec.last)
+    release_lock(self)
+
+    return true
+end
+
+
+return _M

--- a/lib/resty/limit/rate.md
+++ b/lib/resty/limit/rate.md
@@ -1,0 +1,346 @@
+Name
+====
+
+lua-resty-limit-rate - Lua module for limiting request rate for OpenResty/ngx_lua, using the "token bucket" method.
+
+Table of Contents
+=================
+
+* [Status](#status)
+* [Synopsis](#synopsis)
+* [Description](#description)
+* [Methods](#methods)
+  * [new](#new)
+  * [incoming](#incoming)
+  * [set_max_wait](#set_max_wait)
+  * [take](#take)
+  * [take_available](#take_available)
+  * [uncommit](#uncommit)
+* [Limiting Granularity](#limiting-granularity)
+* [Installation](#installation)
+* [Community](#community)
+    * [English Mailing List](#english-mailing-list)
+    * [Chinese Mailing List](#chinese-mailing-list)
+* [Bugs and Patches](#bugs-and-patches)
+* [Author](#author)
+* [Copyright and License](#copyright-and-license)
+* [See Also](#see-also)
+
+Synopsis
+========
+
+```nginx
+http {
+    lua_shared_dict my_limit_rate_store 100m;
+    lua_shared_dict my_locks 100k;
+
+    server {
+        location / {
+            access_by_lua_block {
+                local limit_rate = require "resty.limit.rate"
+
+                local lim, err = limit_rate.new("my_limit_rate_store", 500, 10, 3, 200, {
+                    lock_enable = true, -- use lua-resty-lock
+                    locks_shdict_name = "my_locks",
+                })
+
+                if not lim then
+                    ngx.log(ngx.ERR,
+                            "failed to instantiate a resty.limit.rate object: ", err)
+                    return ngx.exit(500)
+                end
+
+                -- the following call must be per-request.
+                -- here we use the remote (IP) address as the limiting key
+                local key = ngx.var.binary_remote_addr
+                local delay, err = lim:incoming(key, true)
+                -- local delay, err = lim:take(key, 1, ture)
+                if not delay then
+                    if err == "rejected" then
+                        return ngx.exit(503)
+                    end
+                    ngx.log(ngx.ERR, "failed to take token: ", err)
+                    return ngx.exit(500)
+                end
+
+                if delay >= 0.001 then
+                    -- the 2nd return value holds the current avail tokens number
+                    -- of requests for the specified key
+                    local avail = err
+
+                    ngx.sleep(delay)
+                end
+            }
+
+            # content handler goes here. if it is content_by_lua, then you can
+            # merge the Lua code above in access_by_lua into your content_by_lua's
+            # Lua handler to save a little bit of CPU time.
+        }
+
+        location /take_available {
+            access_by_lua_block {
+                local limit_rate = require "resty.limit.rate"
+
+                -- global 20r/s 6000r/5m
+                local lim_global = limit_rate.new("my_limit_rate_store", 100, 6000, 2, nil, {
+                    lock_enable = true,
+                    locks_shdict_name = "my_locks",
+                })
+
+                if not lim_global then
+                    return ngx.exit(500)
+                end
+
+                -- single 2r/s 600r/5m
+                local lim_single = limit_rate.new("my_limit_rate_store", 500, 600, 1, nil, {
+                    locks_shdict_name = "my_locks",
+                })
+
+                if not lim_single then
+                    return ngx.exit(500)
+                end
+
+                local t0, err = lim_global:take_available("__global__", 1)
+                if not t0 then
+                    ngx.log(ngx.ERR, "failed to take global: ", err)
+                    return ngx.exit(500)
+                end
+
+                -- here we use the userid as the limiting key
+                local key = ngx.var.arg_userid or "__single__"
+
+                local t1, err = lim_single:take_available(key, 1)
+                if not t1 then
+                    ngx.log(ngx.ERR, "failed to take single: ", err)
+                    return ngx.exit(500)
+                end
+
+                if t0 == 1 then
+                    return -- global bucket is not hungry
+                else
+                    if t1 == 1 then
+                        return -- single bucket is not hungry
+                    else
+                        return ngx.exit(503)
+                    end
+                end
+            }
+        }
+    }
+}
+```
+
+Description
+===========
+
+This module provides APIs to help the OpenResty/ngx_lua user programmers limit request rate using the "[token bucket](https://en.wikipedia.org/wiki/Token_bucket)" method.
+
+If you want to use multiple different instances of this class at once or use one instance of this class with instances of other classes (like [resty.limit.conn](./conn.md)), then you *must* use the [resty.limit.traffic](./traffic.md) module to combine them.
+
+The main difference between this module and [resty.limit.req](./req.md):
+
+* [resty.limit.req](./req.md) limit request rate using the "leaky bucket" method, this module using the "token bucket" method.
+
+The main difference between this module and [resty.limit.count](./count.md):
+
+* [resty.limit.count](./count.md) offers a straightforward mental model that limit request rate by a fixed number of requests in given time window, but it can sometimes let through twice the number of allowed requests per minute. For example, if our rate limit were 10 requests per minute and a user made 10 requests at 10:00:59, they could make 10 more requests at 10:01:00 because a new counter begins at the start of each minute. In this case, this module able to control more precisely and smoothly.
+
+Methods
+=======
+
+[Back to TOC](#table-of-contents)
+
+new
+---
+**syntax:** `obj, err = class.new(shdict_name, interval, capacity, quantum?, max_wait?, opts?)`
+
+Instantiates an object of this class. The `class` value is returned by the call `require "resty.limit.rate"`.
+
+The method returns a new token bucket that fills at the rate of `quantum` number tokens every `interval`, up to the given maximum `capacity`. The bucket is initially full.
+
+This method takes the following arguments and an optional options table `opts`:
+
+* `shdict_name` is the name of the [lua_shared_dict](https://github.com/openresty/lua-nginx-module#lua_shared_dict) shm zone.
+
+    It is best practice to use separate shm zones for different kinds of limiters.
+
+* `interval` is the time passing between adding tokens, in milliseconds.
+
+* `capacity` is the maximum number of tokens to hold in the bucket.
+
+* `quantum` is the number of tokens to add to the bucket in one interval, this argument is optional, default `1`.
+
+* `max_wait` is the maximum time that we would wait for enough tokens to be added, in milliseconds, this argument is optional, default `nil`, it means infinity.
+
+The options table accepts the following options:
+
+* `lock_enable` When enabled, update shdict state across multiple nginx worker process is atomic; otherwise will have a (small) race-condition window between the "read-and-then-write" behavior, default `false`. See [lua-resty-lock](http://github.com/openresty/lua-resty-lock) for more details.
+
+* `locks_shdict_name` Specifies the shared dictionary name (created by [lua_shared_dict](http://https://github.com/openresty/lua-nginx-module#lua_shared_dict)) for the lock, default `locks`.
+
+On failure, this method returns `nil` and a string describing the error (like a bad `lua_shared_dict` name).
+
+[Back to TOC](#table-of-contents)
+
+incoming
+--------
+**syntax:** `delay, err = obj:take(key, commit)`
+
+Fires a new request incoming event and calculates the delay needed (if any) for the current request
+upon the specified key or whether the user should reject it immediately.
+
+Similar to the [take](#take) method, but this method only takes one token from the bucket at a time.
+
+This method accepts the following arguments:
+
+* `key` is the user specified key to limit the rate.
+
+    Please note that this module does not prefix nor suffix the user key so it is the user's responsibility to ensure the key is unique in the `lua_shared_dict` shm zone.
+
+* `commit` is a boolean value. If set to `true`, the object will actually record the event in the shm zone backing the current object; otherwise it would just be a "dry run" (which is the default).
+
+[Back to TOC](#table-of-contents)
+
+set_max_wait
+------------
+**syntax:** `obj:set_max_wait(max_wait?)`
+
+Overwrites the `max_wait` threshold as specified in the [new](#new) method.
+
+[Back to TOC](#table-of-contents)
+
+take
+----
+**syntax:** `delay, err = obj:take(key, count, commit)`
+
+The method takes count tokens from the bucket without blocking.
+
+This method accepts the following arguments:
+
+* `key` is the user specified key to limit the rate.
+
+    Please note that this module does not prefix nor suffix the user key so it is the user's responsibility to ensure the key is unique in the `lua_shared_dict` shm zone.
+
+* `count` is the number of tokens to remove.
+
+* `commit` is a boolean value. If set to `true`, the object will actually record the event in the shm zone backing the current object; otherwise it would just be a "dry run" (which is the default).
+
+The return values depend on the following cases:
+
+1. If the `max_wait` vaule specified in the [new](#new) or [set_max_wait](#set_max_wait) method, the method will only take tokens from the bucket if the wait time for the tokens is no greater than `max_wait`, and returns the time that the caller should wait until the tokens are actually available, otherwise it returns `nil` and the error string `"rejected"`.
+
+2. If the `max_wait` vaule is nil, it returns the time that the caller should wait until the tokens are actually available.
+
+In addition, this method also returns a second return value indicating the number of the current avail tokens at this point.
+
+If an error occurred (like failures when accessing the `lua_shared_dict` shm zone backing the current object), then this method returns nil and a string describing the error.
+
+This method never sleeps itself. It simply returns a delay if necessary and requires the caller to later invoke the [ngx.sleep](https://github.com/openresty/lua-nginx-module#ngxsleep) method to sleep.
+
+[Back to TOC](#table-of-contents)
+
+take_available
+--------------
+**syntax:** `count, err = obj:take_available(key, count)`
+
+The method takes up to count immediately available tokens from the bucket. It returns the number of tokens removed, or zero if there are no available tokens. It does not block.
+
+This method accepts the following arguments:
+
+* `key` is the user specified key to limit the rate.
+
+    Please note that this module does not prefix nor suffix the user key so it is the user's responsibility to ensure the key is unique in the `lua_shared_dict` shm zone.
+
+* `count` is the number of tokens to remove.
+
+If an error occurred (like failures when accessing the lua_shared_dict shm zone backing the current object), then this method returns nil and a string describing the error.
+
+[Back to TOC](#table-of-contents)
+
+uncommit
+--------
+**syntax:** `ok, err = obj:uncommit(key)`
+
+This tries to undo the commit of the `incoming` call. This is simply an approximation and should be used with care. This method is mainly for being used in the [resty.limit.traffic](./traffic.md) Lua module when combining multiple limiters at the same time.
+
+[Back to TOC](#table-of-contents)
+
+Limiting Granularity
+====================
+
+The limiting works on the granularity of an individual NGINX server instance (including all its worker processes). Thanks to the shm mechanism; we can share state cheaply across all the workers in a single NGINX server instance.
+
+[Back to TOC](#table-of-contents)
+
+Installation
+============
+
+Please see [library installation instructions](../../../README.md#installation).
+
+[Back to TOC](#table-of-contents)
+
+Community
+=========
+
+[Back to TOC](#table-of-contents)
+
+English Mailing List
+--------------------
+
+The [openresty-en](https://groups.google.com/group/openresty-en) mailing list is for English speakers.
+
+[Back to TOC](#table-of-contents)
+
+Chinese Mailing List
+--------------------
+
+The [openresty](https://groups.google.com/group/openresty) mailing list is for Chinese speakers.
+
+[Back to TOC](#table-of-contents)
+
+Bugs and Patches
+================
+
+Please report bugs or submit patches by
+
+1. creating a ticket on the [GitHub Issue Tracker](https://github.com/openresty/lua-resty-limit-traffic/issues),
+1. or posting to the [OpenResty community](#community).
+
+[Back to TOC](#table-of-contents)
+
+Author
+======
+
+Monkey Zhang <timebug.info@gmail.com>, UPYUN Inc.
+
+[Back to TOC](#table-of-contents)
+
+# Copyright and License
+
+This module is licensed under the BSD license.
+
+Copyright (C) 2016-2017, by Yichun "agentzh" Zhang, OpenResty Inc.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+[Back to TOC](#table-of-contents)
+
+See Also
+========
+* module [resty.limit.req](./req.md)
+* module [resty.limit.conn](./conn.md)
+* module [resty.limit.count](./count.md)
+* module [resty.limit.traffic](./traffic.md)
+* library [lua-resty-limit-traffic](../../../README.md)
+* the ngx_lua module: https://github.com/openresty/lua-nginx-module
+* OpenResty: https://openresty.org/
+
+[Back to TOC](#table-of-contents)

--- a/lib/resty/limit/req.md
+++ b/lib/resty/limit/req.md
@@ -1,7 +1,7 @@
 Name
 ====
 
-resty.limit.req - Lua module for limiting request rate for OpenResty/ngx_lua.
+resty.limit.req - Lua module for limiting request rate for OpenResty/ngx_lua, using the "leaky bucket" method.
 
 Table of Contents
 =================
@@ -298,6 +298,7 @@ See Also
 ========
 * module [resty.limit.conn](./conn.md)
 * module [resty.limit.count](./count.md)
+* module [resty.limit.rate](./rate.md)
 * module [resty.limit.traffic](./traffic.md)
 * library [lua-resty-limit-traffic](../../../README.md)
 * the ngx_lua module: https://github.com/openresty/lua-nginx-module

--- a/lib/resty/limit/traffic.md
+++ b/lib/resty/limit/traffic.md
@@ -1,7 +1,7 @@
 Name
 ====
 
-resty.limit.traffic - Lua module for aggregating multiple instances of limiter classes
+resty.limit.traffic - Lua module for aggregating multiple instances of limiter classes.
 
 Table of Contents
 =================
@@ -112,7 +112,7 @@ client address. This module can take into account all the limiters involved with
 introducing any extra delays for the current request.
 
 The concrete limiters supplied can be an instance of the [resty.limit.req](./req.md) class
-or an instance of the [resty.limit.conn](./conn.md) class, or an instance of the [resty.limit.count](./count.md) class, or an instance of any user class
+or an instance of the [resty.limit.conn](./conn.md) class, or an instance of the [resty.limit.count](./count.md) class, or an instance of the [resty.limit.rate](./rate.md) class, or an instance of any user class
 which has a compatible API (see the [combine](#combine) class method for more details).
 
 Methods
@@ -133,12 +133,12 @@ state information returned by each concrete limiter object (if any).
 This method takes the following parameters:
 
 * `limiters` is an array-shaped Lua table that holds all the concrete limiter objects
-(for example, instances of the [resty.limit.req](lib/resty/limit/req.md) and/or
-[resty.limit.conn](lib/resty/limit/conn.md) and/or
-[resty.limit.count](lib/resty/limit/count.md) classes or other compatible objects).
+(for example, instances of the [resty.limit.req](./req.md) and/or
+[resty.limit.conn](./conn.md) and/or [resty.limit.count](./count.md) and/or
+[resty.limit.rate](./rate.md) classes or other compatible objects).
 
     The limiter object must have a method named `incoming` which takes two parameters,
-`key` and `commit`, just like the [resty.limit.req](lib/resty/limit/req.md) objects.
+`key` and `commit`, just like the [resty.limit.req](./req.md) objects.
 In addition, this `incoming` method must return a delay and another opaque value representing
 the current state (or a string describing the error when the first return value is `nil`).
 
@@ -151,8 +151,8 @@ in this table must equate that of the `limiters` table.
 state information returned by each of the concrete limiter object.
 
     For example, instances
-of the [resty.limit.req](lib/resty/limit/req.md) class return the current number of excessive
-requests per second (if exceeding the rate threshold) while instances of the [resty.limit.conn](lib/resty/conn.md) class return the current concurrency level.
+of the [resty.limit.req](./req.md) class return the current number of excessive
+requests per second (if exceeding the rate threshold) while instances of the [resty.limit.conn](./conn.md) class return the current concurrency level.
 
     When missing or set to `nil`, this method does not bother outputing any state information.
 
@@ -261,6 +261,7 @@ See Also
 * module [resty.limit.req](./req.md)
 * module [resty.limit.conn](./conn.md)
 * module [resty.limit.count](./count.md)
+* module [resty.limit.rate](./rate.md)
 * library [lua-resty-limit-traffic](../../../README.md)
 * the ngx_lua module: https://github.com/openresty/lua-nginx-module
 * OpenResty: https://openresty.org/

--- a/t/rate.t
+++ b/t/rate.t
@@ -1,0 +1,782 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+
+repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 4);
+
+#no_diff();
+#no_long_string();
+
+my $pwd = cwd();
+
+our $HttpConfig = <<_EOC_;
+    lua_package_path "$pwd/../lua-resty-lock/lib/?.lua;$pwd/lib/?.lua;;";
+_EOC_
+
+no_long_string();
+run_tests();
+
+__DATA__
+
+=== TEST 1: a single key (always commit)
+--- http_config eval
+"
+$::HttpConfig
+
+    lua_shared_dict store 1m;
+"
+--- config
+    location /t {
+        content_by_lua '
+            local limit_rate = require "resty.limit.rate"
+            ngx.shared.store:flush_all()
+
+            local uri = ngx.var.uri
+            local lim = limit_rate.new("store", 25, 10, 1, 1000)
+            local begin = ngx.now()
+            local uri = ngx.var.uri
+            for i = 1, 50 do
+                local delay, err = lim:incoming(uri, true)
+                if not delay then
+                    ngx.say("failed to limit request: ", err)
+                    return
+                end
+                ngx.sleep(delay)
+            end
+            ngx.sleep(0.001)
+            ngx.say("elapsed: ", ngx.now() - begin, " sec.")
+
+        ';
+    }
+--- request
+GET /t
+--- response_body_like eval
+qr/^elapsed: 1\.00[0-8]\d* sec\.$/
+--- no_error_log
+[error]
+[lua]
+
+
+
+=== TEST 2: multiple keys
+--- http_config eval
+"
+$::HttpConfig
+
+    lua_shared_dict store 1m;
+"
+--- config
+    location /t {
+        content_by_lua '
+            local limit_rate = require "resty.limit.rate"
+            ngx.shared.store:flush_all()
+
+            local lim = limit_rate.new("store", 500, 1, 1, 1000)
+            local delay1, avail1 = lim:incoming("foo", true)
+            local delay2, avail2 = lim:incoming("foo", true)
+            local delay3, avail3 = lim:incoming("bar", true)
+            local delay4, avail4 = lim:incoming("bar", true)
+            ngx.say("delay1: ", delay1)
+            ngx.say("avail1: ", avail1)
+            ngx.say("delay2: ", delay2)
+            ngx.say("avail2: ", avail2)
+            ngx.say("delay3: ", delay3)
+            ngx.say("avail3: ", avail3)
+            ngx.say("delay4: ", delay4)
+            ngx.say("avail4: ", avail4)
+        ';
+    }
+--- request
+GET /t
+--- response_body
+delay1: 0
+avail1: 0
+delay2: 0.5
+avail2: -1
+delay3: 0
+avail3: 0
+delay4: 0.5
+avail4: -1
+--- no_error_log
+[error]
+[lua]
+
+
+
+=== TEST 3: max wait
+--- http_config eval
+"
+$::HttpConfig
+
+    lua_shared_dict store 1m;
+"
+--- config
+    location /t {
+        content_by_lua '
+            local limit_rate = require "resty.limit.rate"
+            local lim = limit_rate.new("store", 500, 2)
+
+            local max_wait = {1000, 2000, 3000}
+
+            for t = 0, 3 do
+                ngx.shared.store:flush_all()
+                if t > 0 then
+                    lim:set_max_wait(max_wait[t])
+                end
+
+                for i = 1, 10 do
+                    local delay, err = lim:incoming("foo", true)
+                    if not delay then
+                        ngx.say(i, ": error: ", err)
+                        break
+                    end
+                end
+            end
+        ';
+    }
+--- request
+GET /t
+--- response_body
+5: error: rejected
+7: error: rejected
+9: error: rejected
+--- no_error_log
+[error]
+[lua]
+
+
+
+=== TEST 4: a single key (do not commit since the 3rd time)
+--- http_config eval
+"
+$::HttpConfig
+
+    lua_shared_dict store 1m;
+"
+--- config
+    location /t {
+        content_by_lua '
+            local limit_rate = require "resty.limit.rate"
+            ngx.shared.store:flush_all()
+
+            local lim = limit_rate.new("store", 500, 1)
+            local key = "bar"
+            for i = 1, 4 do
+                local delay, err = lim:incoming(key, i < 3 and true or false)
+                if not delay then
+                    ngx.say("failed to limit request: ", err)
+                else
+                    ngx.say("delay: ", delay)
+                end
+            end
+        ';
+    }
+--- request
+GET /t
+--- response_body
+delay: 0
+delay: 0.5
+delay: 1
+delay: 1
+--- no_error_log
+[error]
+[lua]
+
+
+
+=== TEST 5: bad value in shdict (integer type)
+--- http_config eval
+"
+$::HttpConfig
+
+    lua_shared_dict store 1m;
+"
+--- config
+    location /t {
+        content_by_lua '
+            local limit_rate = require "resty.limit.rate"
+            ngx.shared.store:flush_all()
+            local key = "bar"
+            ngx.shared.store:set("bar", 32)
+            local lim = limit_rate.new("store", 500, 1)
+            local delay, err = lim:incoming(key, true)
+            if not delay then
+                ngx.say("failed to limit request: ", err)
+            else
+                ngx.say("delay: ", delay)
+            end
+        ';
+    }
+--- request
+GET /t
+--- response_body
+failed to limit request: shdict abused by other users
+--- no_error_log
+[error]
+[lua]
+
+
+
+=== TEST 6: bad value in shdict (string type, and wrong size)
+--- http_config eval
+"
+$::HttpConfig
+
+    lua_shared_dict store 1m;
+"
+--- config
+    location /t {
+        content_by_lua '
+            local limit_rate = require "resty.limit.rate"
+            ngx.shared.store:flush_all()
+            local key = "bar"
+            ngx.shared.store:set("bar", "a")
+            local lim = limit_rate.new("store", 500, 1)
+            local delay, err = lim:incoming(key, true)
+            if not delay then
+                ngx.say("failed to limit request: ", err)
+            else
+                ngx.say("delay: ", delay)
+            end
+        ';
+    }
+--- request
+GET /t
+--- response_body
+failed to limit request: shdict abused by other users
+--- no_error_log
+[error]
+[lua]
+
+
+
+=== TEST 7: a single key (commit & uncommit)
+--- http_config eval
+"
+$::HttpConfig
+
+    lua_shared_dict store 1m;
+"
+--- config
+    location /t {
+        content_by_lua '
+            local limit_rate = require "resty.limit.rate"
+            ngx.shared.store:flush_all()
+            local lim = limit_rate.new("store", 25, 1)
+            local begin = ngx.now()
+            local uri = ngx.var.uri
+            for i = 1, 5 do
+                local delay, err = lim:incoming(uri, true)
+                if not delay then
+                    ngx.say("failed to limit request: ", err)
+                    return
+                end
+                ngx.say(i, ": delay: ", delay)
+                -- --[[
+                if i > 1 then
+                    local ok, err = lim:uncommit(uri)
+                    if not ok then
+                        ngx.say("failed to uncommit: ", err)
+                    end
+                end
+                -- ]]
+            end
+        ';
+    }
+--- request
+GET /t
+--- response_body
+1: delay: 0
+2: delay: 0.025
+3: delay: 0.025
+4: delay: 0.025
+5: delay: 0.025
+--- no_error_log
+[error]
+[lua]
+
+
+
+=== TEST 8: take and lock enabled
+--- http_config eval
+"
+$::HttpConfig
+
+    lua_shared_dict store 1m;
+    lua_shared_dict my_locks 100k;
+"
+--- config
+    location /t {
+        content_by_lua '
+            local limit_rate = require "resty.limit.rate"
+            ngx.shared.store:flush_all()
+
+            local uri = ngx.var.uri
+            local lim = limit_rate.new("store", 250, 10, 1, nil, {
+                lock_enable = true,
+                locks_shdict_name = "my_locks",
+            })
+
+            local now = ngx.now() * 1000
+            local delay1, avail1 = lim:take(uri, 10, true, now)
+            local delay2, avail2 = lim:take(uri, 2, true, now)
+            local delay3, avail3 = lim:take(uri, 2, true, now)
+            local delay4, avail4 = lim:take(uri, 1, true, now)
+
+            ngx.say("delay1: ", delay1)
+            ngx.say("avail1: ", avail1)
+            ngx.say("delay2: ", delay2)
+            ngx.say("avail2: ", avail2)
+            ngx.say("delay3: ", delay3)
+            ngx.say("avail3: ", avail3)
+            ngx.say("delay4: ", delay4)
+            ngx.say("avail4: ", avail4)
+        ';
+    }
+--- request
+GET /t
+--- response_body
+delay1: 0
+avail1: 0
+delay2: 0.5
+avail2: -2
+delay3: 1
+avail3: -4
+delay4: 1.25
+avail4: -5
+--- no_error_log
+[error]
+[lua]
+
+
+
+=== TEST 9: take - offset time and default locks shdict name
+--- http_config eval
+"
+$::HttpConfig
+
+    lua_shared_dict store 1m;
+    lua_shared_dict locks 100k;
+"
+--- config
+    location /t {
+        content_by_lua '
+            local limit_rate = require "resty.limit.rate"
+            ngx.shared.store:flush_all()
+
+            local uri = ngx.var.uri
+            local lim = limit_rate.new("store", 250, 10, 1, nil, {
+                lock_enable = true,
+            })
+
+            local now = ngx.now() * 1000
+            local delay1, avail1 = lim:take(uri, 10, true, now)
+            local delay2, avail2 = lim:take(uri, 1, true, now)
+            local delay3, avail3 = lim:take(uri, 1, true, now + 250)
+
+            ngx.say("delay1: ", delay1)
+            ngx.say("avail1: ", avail1)
+            ngx.say("delay2: ", delay2)
+            ngx.say("avail2: ", avail2)
+            ngx.say("delay3: ", delay3)
+            ngx.say("avail3: ", avail3)
+        ';
+    }
+--- request
+GET /t
+--- response_body
+delay1: 0
+avail1: 0
+delay2: 0.25
+avail2: -1
+delay3: 0.25
+avail3: -1
+--- no_error_log
+[error]
+[lua]
+
+
+
+=== TEST 10: take - more than capacity
+--- http_config eval
+"
+$::HttpConfig
+
+    lua_shared_dict store 1m;
+"
+--- config
+    location /t {
+        content_by_lua '
+            local limit_rate = require "resty.limit.rate"
+            ngx.shared.store:flush_all()
+
+            local uri = ngx.var.uri
+            local lim = limit_rate.new("store", 1, 10)
+
+            local now = ngx.now() * 1000
+            local delay1, avail1 = lim:take(uri, 10, true, now)
+            local delay2, avail2 = lim:take(uri, 15, true, now + 20)
+
+            ngx.say("delay1: ", delay1)
+            ngx.say("avail1: ", avail1)
+            ngx.say("delay2: ", delay2)
+            ngx.say("avail2: ", avail2)
+        ';
+    }
+--- request
+GET /t
+--- response_body
+delay1: 0
+avail1: 0
+delay2: 0.005
+avail2: -5
+--- no_error_log
+[error]
+[lua]
+
+
+
+=== TEST 11: take - offset sub-quantum time
+--- http_config eval
+"
+$::HttpConfig
+
+    lua_shared_dict store 1m;
+"
+--- config
+    location /t {
+        content_by_lua '
+            local limit_rate = require "resty.limit.rate"
+            ngx.shared.store:flush_all()
+
+            local uri = ngx.var.uri
+            local lim = limit_rate.new("store", 10, 10)
+
+            local now = ngx.now() * 1000
+            local delay1, avail1 = lim:take(uri, 10, true, now)
+            local delay2, avail2 = lim:take(uri, 1, true, now + 7)
+            local delay3, avail3 = lim:take(uri, 1, true, now + 8)
+            local delay4, avail4 = lim:take(uri, 1, true, now + 10)
+            local delay5, avail5 = lim:take(uri, 1, true, now + 25)
+
+            ngx.say("delay1: ", delay1)
+            ngx.say("avail1: ", avail1)
+            ngx.say("delay2: ", delay2)
+            ngx.say("avail2: ", avail2)
+            ngx.say("delay3: ", delay3)
+            ngx.say("avail3: ", avail3)
+            ngx.say("delay4: ", delay4)
+            ngx.say("avail4: ", avail4)
+            ngx.say("delay5: ", delay5)
+            ngx.say("avail5: ", avail5)
+        ';
+    }
+--- request
+GET /t
+--- response_body
+delay1: 0
+avail1: 0
+delay2: 0.003
+avail2: -1
+delay3: 0.012
+avail3: -2
+delay4: 0.02
+avail4: -2
+delay5: 0.015
+avail5: -2
+--- no_error_log
+[error]
+[lua]
+
+
+
+
+=== TEST 12: take - within capacity
+--- http_config eval
+"
+$::HttpConfig
+
+    lua_shared_dict store 1m;
+"
+--- config
+    location /t {
+        content_by_lua '
+            local limit_rate = require "resty.limit.rate"
+            ngx.shared.store:flush_all()
+
+            local uri = ngx.var.uri
+            local lim = limit_rate.new("store", 10, 5)
+
+            local now = ngx.now() * 1000
+            local delay1, avail1 = lim:take(uri, 5, true, now)
+            local delay2, avail2 = lim:take(uri, 5, true, now + 60)
+            local delay3, avail3 = lim:take(uri, 1, true, now + 60)
+            local delay4, avail4 = lim:take(uri, 2, true, now + 80)
+
+            ngx.say("delay1: ", delay1)
+            ngx.say("avail1: ", avail1)
+            ngx.say("delay2: ", delay2)
+            ngx.say("avail2: ", avail2)
+            ngx.say("delay3: ", delay3)
+            ngx.say("avail3: ", avail3)
+            ngx.say("delay4: ", delay4)
+            ngx.say("avail4: ", avail4)
+        ';
+    }
+--- request
+GET /t
+--- response_body
+delay1: 0
+avail1: 0
+delay2: 0
+avail2: 0
+delay3: 0.01
+avail3: -1
+delay4: 0.01
+avail4: -1
+--- no_error_log
+[error]
+[lua]
+
+
+
+=== TEST 13: take - max wait
+--- http_config eval
+"
+$::HttpConfig
+
+    lua_shared_dict store 1m;
+"
+--- config
+    location /t {
+        content_by_lua '
+            local limit_rate = require "resty.limit.rate"
+            ngx.shared.store:flush_all()
+
+            local uri = ngx.var.uri
+            local lim = limit_rate.new("store", 1, 10)
+
+            local now = ngx.now() * 1000
+            local delay1, err1 = lim:take(uri, 10, true, now)
+            lim:set_max_wait(4)
+            local delay2, err2 = lim:take(uri, 15, true, now + 20)
+            local delay3, err3 = lim:take(uri, 10, true, now + 25)
+
+            ngx.say("delay1: ", delay1)
+            ngx.say("err1: ", err1)
+            ngx.say("delay2: ", delay2)
+            ngx.say("err2: ", err2)
+            ngx.say("delay3: ", delay3)
+            ngx.say("err3: ", err3)
+        ';
+    }
+--- request
+GET /t
+--- response_body
+delay1: 0
+err1: 0
+delay2: nil
+err2: rejected
+delay3: 0
+err3: 0
+--- no_error_log
+[error]
+[lua]
+
+
+
+=== TEST 14: take - count greater than capacity
+--- http_config eval
+"
+$::HttpConfig
+
+    lua_shared_dict store 1m;
+"
+--- config
+    location /t {
+        content_by_lua '
+            local limit_rate = require "resty.limit.rate"
+            ngx.shared.store:flush_all()
+
+            local uri = ngx.var.uri
+            local lim = limit_rate.new("store", 1, 10, 1, 4)
+
+            local now = ngx.now() * 1000
+            local delay1, err1 = lim:take(uri, 15, true, now)
+            lim:set_max_wait()
+            local delay2, err2 = lim:take(uri, 15, true, now + 20)
+
+            ngx.say("delay1: ", delay1)
+            ngx.say("err1: ", err1)
+            ngx.say("delay2: ", delay2)
+            ngx.say("err2: ", err2)
+        ';
+    }
+--- request
+GET /t
+--- response_body
+delay1: nil
+err1: rejected
+delay2: 0.005
+err2: -5
+--- no_error_log
+[error]
+[lua]
+
+
+
+=== TEST 15: take_available
+--- http_config eval
+"
+$::HttpConfig
+
+    lua_shared_dict store 1m;
+"
+--- config
+    location /t {
+        content_by_lua '
+            local limit_rate = require "resty.limit.rate"
+            ngx.shared.store:flush_all()
+
+            local uri = ngx.var.uri
+            local lim = limit_rate.new("store", 250, 10)
+
+            local now = ngx.now() * 1000
+            local count1, _ = lim:take_available(uri, 5, now)
+            local count2, _ = lim:take_available(uri, 2, now)
+            local count3, _ = lim:take_available(uri, 5, now)
+            local count4, _ = lim:take_available(uri, 1, now)
+
+            ngx.say("count1: ", count1)
+            ngx.say("count2: ", count2)
+            ngx.say("count3: ", count3)
+            ngx.say("count4: ", count4)
+        ';
+    }
+--- request
+GET /t
+--- response_body
+count1: 5
+count2: 2
+count3: 3
+count4: 0
+--- no_error_log
+[error]
+[lua]
+
+
+
+=== TEST 16: take_available - offset time
+--- http_config eval
+"
+$::HttpConfig
+
+    lua_shared_dict store 1m;
+"
+--- config
+    location /t {
+        content_by_lua '
+            local limit_rate = require "resty.limit.rate"
+            ngx.shared.store:flush_all()
+
+            local uri = ngx.var.uri
+            local lim = limit_rate.new("store", 250, 10)
+
+            local now = ngx.now() * 1000
+            local count1, _ = lim:take_available(uri, 0, now)
+            local count2, _ = lim:take_available(uri, 10, now)
+            local count3, _ = lim:take_available(uri, 1, now)
+            local count4, _ = lim:take_available(uri, 1, now + 250)
+
+            ngx.say("count1: ", count1)
+            ngx.say("count2: ", count2)
+            ngx.say("count3: ", count3)
+            ngx.say("count4: ", count4)
+        ';
+    }
+--- request
+GET /t
+--- response_body
+count1: 0
+count2: 10
+count3: 0
+count4: 1
+--- no_error_log
+[error]
+[lua]
+
+
+
+=== TEST 17: take_available - more than capacity
+--- http_config eval
+"
+$::HttpConfig
+
+    lua_shared_dict store 1m;
+"
+--- config
+    location /t {
+        content_by_lua '
+            local limit_rate = require "resty.limit.rate"
+            ngx.shared.store:flush_all()
+
+            local uri = ngx.var.uri
+            local lim = limit_rate.new("store", 1, 10)
+
+            local now = ngx.now() * 1000
+            local count1, _ = lim:take_available(uri, 10, now)
+            local count2, _ = lim:take_available(uri, 15, now + 20)
+
+            ngx.say("count1: ", count1)
+            ngx.say("count2: ", count2)
+        ';
+    }
+--- request
+GET /t
+--- response_body
+count1: 10
+count2: 10
+--- no_error_log
+[error]
+[lua]
+
+
+
+=== TEST 18: take_available - within capacity
+--- http_config eval
+"
+$::HttpConfig
+
+    lua_shared_dict store 1m;
+"
+--- config
+    location /t {
+        content_by_lua '
+            local limit_rate = require "resty.limit.rate"
+            ngx.shared.store:flush_all()
+
+            local uri = ngx.var.uri
+            local lim = limit_rate.new("store", 10, 5)
+
+            local now = ngx.now() * 1000
+            local count1, _ = lim:take_available(uri, 5, now)
+            local count2, _ = lim:take_available(uri, 5, now + 60)
+            local count3, _ = lim:take_available(uri, 1, now + 70)
+
+            ngx.say("count1: ", count1)
+            ngx.say("count2: ", count2)
+            ngx.say("count3: ", count3)
+        ';
+    }
+--- request
+GET /t
+--- response_body
+count1: 5
+count2: 5
+count3: 1
+--- no_error_log
+[error]
+[lua]


### PR DESCRIPTION
This PR have been discussed at https://github.com/openresty/lua-resty-limit-traffic/pull/26.

This module provides APIs to help the OpenResty/ngx_lua user programmers limit request rate using the "[token bucket](https://en.wikipedia.org/wiki/Token_bucket)" method.

Small differences with existing modules, this module use `resty.lock` to make sure shdict operations across multiple nginx worker process is atomic, but default disable.