### PR TITLE
fix: miss to uncommit the last one in resty.limit.traffic's list

### DIFF
--- a/lib/resty/limit/traffic.lua
+++ b/lib/resty/limit/traffic.lua
@@ -42,6 +42,7 @@ function _M.combine(limiters, keys, states)
                 -- we intentionally ignore any errors returned below.
                 limiters[j]:uncommit(keys[j])
             end
+            limiters[n]:uncommit(keys[n])
             return nil, err
         end
         if states then


### PR DESCRIPTION
I fix a bug which may make conn limiter's shared.dict counters increase abnormally.
This is because the original code snippets forget to `uncommit` the last limiter if a former one returns `reject`.
Here is an example:
we have a traffic limiter that combines two conn limiters:
```
{
    {'conn': 2, 'burst': 0, 'default_conn_delay': 0.1, 'key': 'binary_remote_addr'},
    {'conn': 10, 'burst': 0, 'default_conn_delay': 0.1, 'key': 'http_host'}
}
```
The first one will always reach `reject` status before the second one does. And the first one will end request(exiting 503 etc..), so the second conn limiter actually doesn't commit the request. but in the code, it's shared.dict value will raise by 1..And users may forget(or have no chance) to set the commited limiter into `ngx.ctx`. if `ngx.ctx` is unable to be set, `leaving` this request is impossible in log phase. So the connection value of the last limiter keeps increasing abnormally.

So I add an `uncommit` operation to the last index of the limiters, which I think is in accordance with the `combine` mehtod's logic: one should `uncommit` all of the other limiters if one limiter has already rejected request.
