### PR TITLE
feat: resty.limit.count support new shared dict incr function

### DIFF
--- a/lib/resty/limit/count.lua
+++ b/lib/resty/limit/count.lua
@@ -44,7 +44,9 @@ function _M.new(dict_name, limit, window)
     return setmetatable(self, mt)
 end
 
-function _M.incoming_new(self, key, commit)
+-- incoming function using incr with init_ttl
+-- need OpenResty version > v0.10.12rc2
+local function incoming_new(self, key, commit)
     local dict = self.dict
     local limit = self.limit
     local window = self.window
@@ -67,7 +69,8 @@ function _M.incoming_new(self, key, commit)
     return 0, remaining
 end
 
-function _M.incoming_old(self, key, commit)
+-- incoming function using incr and expire
+local function incoming_old(self, key, commit)
     local dict = self.dict
     local limit = self.limit
     local window = self.window
@@ -111,14 +114,7 @@ function _M.incoming_old(self, key, commit)
     return 0, remaining
 end
 
-function _M.incoming(self, key, commit)
-    if incr_support_init_ttl then
-        return self:incoming_new(key, commit)
-    else
-        return self:incoming_old(key, commit)
-    end
-end
-
+_M.incoming = incr_support_init_ttl and incoming_new or incoming_old
 
 -- uncommit remaining and return remaining value
 function _M.uncommit(self, key)


### PR DESCRIPTION
Hi,
The aim of this pr is to make `resty.limit.count`'s incoming function using the latest type of shared dict's `incr` function, which supports setting expire time when increasing an unexisting key, and it is also compatible with the old version of OpenResty, just as mentioned in  https://github.com/openresty/lua-resty-limit-traffic/pull/34#issuecomment-765246987.

I'm doing some pressure tests recently to test the stability of lua-resty-limit-traffic module and found some problems under high volume(possibly due to the concurrent situation and two separate atomic operation(incr and expire) calls in `incoming`, see https://github.com/openresty/lua-resty-limit-traffic/issues/23#issuecomment-332912949 and https://github.com/openresty/lua-resty-limit-traffic/issues/47#issue-473159401). However, I found that when I'm using the latest `incr` function which supports expire time(which makes the two operation combines into an atomic one(done within the same lock, see https://github.com/openresty/lua-nginx-module/blob/3f33dd862a3d8539b96dda09b624c89712cbe0c8/src/ngx_http_lua_shdict.c#L1889), the problem hardly occurs. So I think it is perhaps a good idea to use incr with expire time arg instead of separate them into two operations.

