### PR TITLE
fix: remove unused variable

### DIFF
--- a/lib/resty/limit/count.lua
+++ b/lib/resty/limit/count.lua
@@ -51,7 +51,7 @@ local function incoming_new(self, key, commit)
     local limit = self.limit
     local window = self.window
 
-    local remaining, ok, err
+    local remaining, err
 
     if commit then
         remaining, err = dict:incr(key, -1, limit, window)


### PR DESCRIPTION
This PR may appear spammy and it might occur that the existing state is by design. But here goes nothing.